### PR TITLE
Fix yaw pitch roll

### DIFF
--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -18,9 +18,9 @@ CartesianCoordinates
     :members:
     :no-inherited-members:
 
-Spherical
----------
-.. autoclass:: zoloto.coords.Spherical
+SphericalCoordinates
+--------------------
+.. autoclass:: zoloto.coords.SphericalCoordinates
     :members:
     :no-inherited-members:
 

--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -6,9 +6,9 @@ Orientation
 .. autoclass:: zoloto.coords.Orientation
     :members:
 
-Coordinates
------------
-.. autoclass:: zoloto.coords.Coordinates
+PixelCoordinates
+----------------
+.. autoclass:: zoloto.coords.PixelCoordinates
     :members:
     :no-inherited-members:
 

--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -12,9 +12,9 @@ PixelCoordinates
     :members:
     :no-inherited-members:
 
-ThreeDCoordinates
------------------
-.. autoclass:: zoloto.coords.ThreeDCoordinates
+CartesianCoordinates
+--------------------
+.. autoclass:: zoloto.coords.CartesianCoordinates
     :members:
     :no-inherited-members:
 

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -78,36 +78,36 @@ def test_repr(euler_angles: tuple[float, float, float]) -> None:
         pytest.param(
             CartesianCoordinates(0, 0, 1),
             SphericalCoordinates(
-                rot_x=0,
-                rot_y=0,
-                dist=1,
+                theta=math.pi / 2,
+                phi=math.pi / 2,
+                distance=1,
             ),
             id="in-front-of-you",
         ),
         pytest.param(
             CartesianCoordinates(0, 1, 0),
             SphericalCoordinates(
-                rot_x=math.pi / 2,
-                rot_y=0,
-                dist=1,
+                theta=0,
+                phi=0,
+                distance=1,
             ),
             id="above-you",
         ),
         pytest.param(
             CartesianCoordinates(1, 0, 0),
             SphericalCoordinates(
-                rot_x=0,
-                rot_y=math.pi / 2,
-                dist=1,
+                theta=math.pi / 2,
+                phi=0,
+                distance=1,
             ),
             id="to-one-side",
         ),
         pytest.param(
             CartesianCoordinates(1000, 1000, 0),
             SphericalCoordinates(
-                rot_x=math.pi / 2,
-                rot_y=math.pi / 2,
-                dist=1414,
+                theta=0.7853981633974484,  # math.pi / 4, with floating point error
+                phi=0,
+                distance=1414,
             ),
             id="to-one-side-and-up",
         ),

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,11 +1,14 @@
 """Tests for coordinates classes."""
 from __future__ import annotations
 
+import math
+
+import pytest
 from hypothesis import given
 from hypothesis.strategies import floats, tuples
 from pyquaternion import Quaternion
 
-from zoloto.coords import Orientation
+from zoloto.coords import CartesianCoordinates, Orientation, SphericalCoordinates
 
 
 @given(tuples(floats(), floats(), floats()))
@@ -62,3 +65,57 @@ def test_repr(euler_angles: tuple[float, float, float]) -> None:
 
     for name, val in zip(names, ypr):
         assert f"{name}={val}" in repr_str
+
+
+@pytest.mark.parametrize(
+    "cartesian,expected",
+    [
+        pytest.param(
+            CartesianCoordinates(0, 0, 0),
+            SphericalCoordinates(0, 0, 0),
+            id="origin",
+        ),
+        pytest.param(
+            CartesianCoordinates(0, 0, 1),
+            SphericalCoordinates(
+                rot_x=0,
+                rot_y=0,
+                dist=1,
+            ),
+            id="in-front-of-you",
+        ),
+        pytest.param(
+            CartesianCoordinates(0, 1, 0),
+            SphericalCoordinates(
+                rot_x=math.pi / 2,
+                rot_y=0,
+                dist=1,
+            ),
+            id="above-you",
+        ),
+        pytest.param(
+            CartesianCoordinates(1, 0, 0),
+            SphericalCoordinates(
+                rot_x=0,
+                rot_y=math.pi / 2,
+                dist=1,
+            ),
+            id="to-one-side",
+        ),
+        pytest.param(
+            CartesianCoordinates(1000, 1000, 0),
+            SphericalCoordinates(
+                rot_x=math.pi / 2,
+                rot_y=math.pi / 2,
+                dist=1414,
+            ),
+            id="to-one-side-and-up",
+        ),
+    ],
+)
+def test_spherical_from_cartesian(
+    cartesian: CartesianCoordinates,
+    expected: SphericalCoordinates,
+) -> None:
+    spherical = SphericalCoordinates.from_cartesian(cartesian)
+    assert spherical == expected

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from typing import Any
 from unittest import TestCase
 from unittest.mock import patch
@@ -71,10 +72,10 @@ class MarkerTestCase(TestCase):
         self.assertAlmostEqual(int(z), 910, delta=100)  # HACK: Sometimes it changes
 
     def test_spherical_coordinates(self) -> None:
-        rot_x, rot_y, dist = self.marker.spherical
+        dist, rot_x, rot_y = self.marker.spherical
         self.assertEqual(dist, self.marker.distance)
-        self.assertAlmostEqual(rot_x, 0, delta=0.1)
-        self.assertAlmostEqual(rot_y, 0, delta=0.1)
+        self.assertAlmostEqual(rot_x, math.pi / 2, delta=0.1)
+        self.assertAlmostEqual(rot_y, math.pi / 2, delta=0.1)
 
     def test_as_dict(self) -> None:
         marker_dict = self.marker.as_dict()
@@ -119,7 +120,7 @@ class MarkerTestCase(TestCase):
 
             self.assertIsType(self.marker.spherical.rot_x, float)
             self.assertIsType(self.marker.spherical.rot_y, float)
-            self.assertIsType(self.marker.spherical.dist, int)
+            self.assertIsType(self.marker.spherical.distance, int)
 
             self.assertIsType(self.marker.cartesian.x, float)
             self.assertIsType(self.marker.cartesian.y, float)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -20,7 +20,7 @@ def test_exposes_marker_type() -> None:
 
 @pytest.mark.parametrize(
     "coordinate_struct",
-    ["PixelCoordinates", "Orientation", "ThreeDCoordinates", "Spherical"],
+    ["PixelCoordinates", "Orientation", "CartesianCoordinates", "Spherical"],
 )
 def test_exposes_coordinates(coordinate_struct: str) -> None:
     assert getattr(zoloto, coordinate_struct) == getattr(

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -20,7 +20,7 @@ def test_exposes_marker_type() -> None:
 
 @pytest.mark.parametrize(
     "coordinate_struct",
-    ["Coordinates", "Orientation", "ThreeDCoordinates", "Spherical"],
+    ["PixelCoordinates", "Orientation", "ThreeDCoordinates", "Spherical"],
 )
 def test_exposes_coordinates(coordinate_struct: str) -> None:
     assert getattr(zoloto, coordinate_struct) == getattr(

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -20,7 +20,7 @@ def test_exposes_marker_type() -> None:
 
 @pytest.mark.parametrize(
     "coordinate_struct",
-    ["PixelCoordinates", "Orientation", "CartesianCoordinates", "Spherical"],
+    ["PixelCoordinates", "Orientation", "CartesianCoordinates", "SphericalCoordinates"],
 )
 def test_exposes_coordinates(coordinate_struct: str) -> None:
     assert getattr(zoloto, coordinate_struct) == getattr(

--- a/zoloto/__init__.py
+++ b/zoloto/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from zoloto.coords import Orientation, PixelCoordinates, Spherical, ThreeDCoordinates
+from zoloto.coords import CartesianCoordinates, Orientation, PixelCoordinates, Spherical
 from zoloto.marker import Marker
 from zoloto.marker_type import MarkerType
 
@@ -8,10 +8,10 @@ __version__ = "0.9.0"
 
 
 __all__ = [
+    "CartesianCoordinates",
     "Orientation",
     "PixelCoordinates",
     "Spherical",
-    "ThreeDCoordinates",
     "Marker",
     "MarkerType",
 ]

--- a/zoloto/__init__.py
+++ b/zoloto/__init__.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from zoloto.coords import CartesianCoordinates, Orientation, PixelCoordinates, Spherical
+from zoloto.coords import (
+    CartesianCoordinates,
+    Orientation,
+    PixelCoordinates,
+    SphericalCoordinates,
+)
 from zoloto.marker import Marker
 from zoloto.marker_type import MarkerType
 
@@ -11,7 +16,7 @@ __all__ = [
     "CartesianCoordinates",
     "Orientation",
     "PixelCoordinates",
-    "Spherical",
+    "SphericalCoordinates",
     "Marker",
     "MarkerType",
 ]

--- a/zoloto/__init__.py
+++ b/zoloto/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from zoloto.coords import Coordinates, Orientation, Spherical, ThreeDCoordinates
+from zoloto.coords import Orientation, PixelCoordinates, Spherical, ThreeDCoordinates
 from zoloto.marker import Marker
 from zoloto.marker_type import MarkerType
 
@@ -8,8 +8,8 @@ __version__ = "0.9.0"
 
 
 __all__ = [
-    "Coordinates",
     "Orientation",
+    "PixelCoordinates",
     "Spherical",
     "ThreeDCoordinates",
     "Marker",

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -132,7 +132,7 @@ class Orientation:
         # and rotate so that 0 yaw is facing the camera
         quaternion = Quaternion(
             initial_rotation.w,
-            initial_rotation.z,
+            -initial_rotation.z,
             -initial_rotation.x,
             initial_rotation.y,
         ) * self.__MARKER_ORIENTATION_CORRECTION

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -1,3 +1,10 @@
+"""
+Contructs to convert the R and t vectors into other coordinate systems.
+
+Setting the environment variable ZOLOTO_LEGACY_AXIS uses the axis that were
+used up to version 0.9.0. Otherwise the conventional right-handed axis is used
+where x is forward, y is left and z is upward.
+"""
 from __future__ import annotations
 
 import os

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -27,8 +27,21 @@ class PixelCoordinates(NamedTuple):
 
 class CartesianCoordinates(NamedTuple):
     """
-    Cartesian coordinates, rotated on their side.
+    Conventional:
+    The X axis extends directly away from the camera. Zero is at the camera.
+    Increasing values indicate greater distance from the camera.
 
+    The Y axis is horizontal relative to the camera's perspective, i.e: right
+    to left within the frame of the image. Zero is at the centre of the image.
+    Increasing values indicate greater distance to the left.
+
+    The Z axis is vertical relative to the camera's perspective, i.e: down to
+    up within the frame of the image. Zero is at the centre of the image.
+    Increasing values indicate greater distance above the centre of the image.
+
+    More information: https://w.wiki/5zbE
+
+    Legacy:
     The X axis is horizontal relative to the camera's perspective, i.e: left &
     right within the frame of the image. Zero is at the centre of the image.
     Increasing values indicate greater distance to the right.
@@ -51,6 +64,17 @@ class CartesianCoordinates(NamedTuple):
     x: float
     y: float
     z: float
+
+    @classmethod
+    def from_tvec(cls, x: float, y: float, z: float) -> CartesianCoordinates:
+        if os.environ.get('ZOLOTO_LEGACY_AXIS'):
+            return CartesianCoordinates(
+                x=x, y=y, z=z,
+            )
+        else:
+            return CartesianCoordinates(
+                x=z, y=-x, z=-y,
+            )
 
 
 class SphericalCoordinates(NamedTuple):
@@ -110,7 +134,7 @@ RotationMatrix = Tuple[ThreeTuple, ThreeTuple, ThreeTuple]
 class Orientation:
     """The orientation of an object in 3-D space."""
 
-    # The rotation so that (0, 0, 0) in yaw_pitch_roll is a marker facing
+    # The rotation so that (0, 0, 0) in _yaw_pitch_roll is a marker facing
     # directly at the camera, not away
     __MARKER_ORIENTATION_CORRECTION = Quaternion(matrix=np.array([
         [-1, 0, 0],

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -120,7 +120,7 @@ class SphericalCoordinates(NamedTuple):
         if os.environ.get('ZOLOTO_LEGACY_AXIS'):
             return self.phi - (math.pi / 2)
         else:
-            raise AttributeError("Rotation around this axis is not used")
+            raise AttributeError("That axis is not available in the selected coordinate system.")
 
     @property
     def rot_y(self) -> float:
@@ -153,7 +153,7 @@ class SphericalCoordinates(NamedTuple):
         Legacy: This is unused.
         """
         if os.environ.get('ZOLOTO_LEGACY_AXIS'):
-            raise AttributeError("Rotation around this axis is not used")
+            raise AttributeError("That axis is not available in the selected coordinate system.")
         else:
             return self.theta
 

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -79,10 +79,12 @@ class SphericalCoordinates(NamedTuple):
 
     @property
     def rot_x(self) -> float:
+        """Approximate rotation around the x-axis, an alias for ``self.theta``."""
         return self.theta
 
     @property
     def rot_y(self) -> float:
+        """Rotation around the y-axis, an alias for ``self.phi``."""
         return self.phi
 
     @classmethod

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -24,6 +24,22 @@ class PixelCoordinates(NamedTuple):
 
 class CartesianCoordinates(NamedTuple):
     """
+    Cartesian coordinates, rotated on their side.
+
+    The X axis is horizontal relative to the camera's perspective, i.e: left &
+    right within the frame of the image. Zero is at the centre of the image.
+    Increasing values indicate greater distance to the right.
+
+    The Y axis is vertical relative to the camera's perspective, i.e: up & down
+    within the frame of the image. Zero is at the centre of the image.
+    Increasing values indicate greater distance below the centre of the image.
+
+    The Z axis extends directly away from the camera. Zero is at the camera.
+    Increasing values indicate greater distance from the camera.
+
+    These match traditional cartesian coordinates when the camera is facing
+    upwards.
+
     :param float x: X coordinate
     :param float y: Y coordinate
     :param float z: Z coordinate

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -64,17 +64,58 @@ class Orientation:
 
     @property
     def rot_x(self) -> float:
-        """Get rotation angle around x axis in radians."""
+        """
+        Get rotation angle around X axis in radians.
+
+        The X axis is horizontal relative to the camera's perspective, i.e: left
+        & right within the frame of the image.
+
+        Increasing values represent an increasing clockwise rotation of the
+        marker as seen from the camera's left.
+
+        Zero values for April Tags markers have the marker facing away from the
+        camera. The practical effect of this is that an April Tags marker facing
+        the camera square-on will have a value of ``pi`` (or equivalently
+        ``-pi``) and the value will decrease as the marker diverges from
+        square-on.
+
+        For observed markers positive values therefore indicate a rotation of
+        the top of the marker away from the camera, such that marker could be
+        said to be leaning backwards, with the value decreasing as the marker
+        leans back further.
+        """
         return self.roll
 
     @property
     def rot_y(self) -> float:
-        """Get rotation angle around y axis in radians."""
+        """
+        Get rotation angle around Y axis in radians.
+
+        The Y axis is vertical relative to the camera's perspective, i.e: up &
+        down within the frame of the image.
+
+        Positive values indicate a rotation of an observed marker towards the
+        camera's right. This is a rotation of the marker counter-clockwise about
+        the Y axis as seen from above the marker.
+
+        Zero values for April Tags markers have the marker facing the camera
+        square-on.
+        """
         return self.pitch
 
     @property
     def rot_z(self) -> float:
-        """Get rotation angle around z axis in radians."""
+        """
+        Get rotation angle around Z axis in radians.
+
+        The Z axis extends directly away from the camera.
+
+        Positive values indicate a rotation counter-clockwise from the
+        perspective of the camera.
+
+        Zero values for April Tags markers have the marker reference point at
+        the top left.
+        """
         return self.yaw
 
     @property

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Iterator, NamedTuple, Tuple
 
 from cached_property import cached_property
@@ -52,14 +53,38 @@ class CartesianCoordinates(NamedTuple):
 
 class SphericalCoordinates(NamedTuple):
     """
-    :param float rot_x: Rotation around the X-axis, in radians
-    :param float rot_y: Rotation around the Y-axis, in radians
+    Twin-angle + distance coordinates, from the perspective of the camera.
+
+    These are not spherical coordinates in the typical sense as each of the
+    angles are computed separately rather than being applicable one after the
+    other. This results in some real world positions being considered equal by
+    this type, however such positions are expected to be out of the viewable
+    world for a standard camera.
+
+    The axes definitions are as for ``CartesianCoordinates``.
+
+    :param float rot_x: Rotation around the X-axis, in radians. Zero is at the
+        centre of the image. Increasing values indicate greater distance towards
+        the bottom of the image.
+    :param float rot_y: Rotation around the Y-axis, in radians. Zero is at the
+        centre of the image. Increasing values indicate greater distance to the
+        right within the image.
     :param float dist: Distance
     """
 
     rot_x: float
     rot_y: float
     dist: int
+
+    @classmethod
+    def from_cartesian(cls, cartesian: CartesianCoordinates) -> SphericalCoordinates:
+        distance = math.sqrt(sum(x**2 for x in cartesian))
+        x, y, z = cartesian
+        return cls(
+            rot_x=math.atan2(y, z),
+            rot_y=math.atan2(x, z),
+            dist=int(distance),
+        )
 
 
 ThreeTuple = Tuple[float, float, float]

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -22,7 +22,7 @@ class PixelCoordinates(NamedTuple):
     y: float
 
 
-class ThreeDCoordinates(NamedTuple):
+class CartesianCoordinates(NamedTuple):
     """
     :param float x: X coordinate
     :param float y: Y coordinate

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -7,8 +7,13 @@ from cv2 import Rodrigues
 from pyquaternion import Quaternion
 
 
-class Coordinates(NamedTuple):
+class PixelCoordinates(NamedTuple):
     """
+    Coordinates within an image made up from pixels.
+
+    This type allows float values to account for computed locations which are
+    not limited to exact pixel boundaries.
+
     :param float x: X coordinate
     :param float y: Y coordinate
     """

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -34,7 +34,7 @@ class CartesianCoordinates(NamedTuple):
     z: float
 
 
-class Spherical(NamedTuple):
+class SphericalCoordinates(NamedTuple):
     """
     :param float rot_x: Rotation around the X-axis, in radians
     :param float rot_y: Rotation around the Y-axis, in radians

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -70,7 +70,7 @@ class BaseMarker(ABC):
 
     @cached_property
     def spherical(self) -> SphericalCoordinates:
-        return SphericalCoordinates.from_cartesian(self.cartesian)
+        return SphericalCoordinates.from_tvec(*self._tvec.tolist())
 
     @property
     def cartesian(self) -> CartesianCoordinates:

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -74,7 +74,7 @@ class BaseMarker(ABC):
 
     @property
     def cartesian(self) -> CartesianCoordinates:
-        return CartesianCoordinates(*self._tvec.tolist())
+        return CartesianCoordinates.from_tvec(*self._tvec.tolist())
 
     @property
     def _rvec(self) -> NDArray:

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+import numpy as np
 from cached_property import cached_property
 from cv2 import aruco
 from numpy.typing import NDArray
@@ -56,11 +57,8 @@ class BaseMarker(ABC):
 
     @cached_property
     def pixel_centre(self) -> PixelCoordinates:
-        tl, _, br, _ = self.pixel_corners
-        return PixelCoordinates(
-            x=tl.x + (self.size / 2) - 1,
-            y=br.y - (self.size / 2),
-        )
+        centre = np.mean(self._pixel_corners, axis=0)
+        return PixelCoordinates(x=centre[0], y=centre[1])
 
     @cached_property
     def distance(self) -> int:

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -11,7 +11,12 @@ from numpy.typing import NDArray
 from zoloto.utils import cached_method
 
 from .calibration import CalibrationParameters
-from .coords import CartesianCoordinates, Orientation, PixelCoordinates, Spherical
+from .coords import (
+    CartesianCoordinates,
+    Orientation,
+    PixelCoordinates,
+    SphericalCoordinates,
+)
 from .exceptions import MissingCalibrationsError
 from .marker_type import MarkerType
 
@@ -67,9 +72,9 @@ class BaseMarker(ABC):
         return Orientation(*self._rvec)
 
     @cached_property
-    def spherical(self) -> Spherical:
+    def spherical(self) -> SphericalCoordinates:
         x, y, z = self._tvec
-        return Spherical(
+        return SphericalCoordinates(
             rot_x=float(arctan2(y, z)), rot_y=float(arctan2(x, z)), dist=self.distance
         )
 

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -11,7 +11,7 @@ from numpy.typing import NDArray
 from zoloto.utils import cached_method
 
 from .calibration import CalibrationParameters
-from .coords import Coordinates, Orientation, Spherical, ThreeDCoordinates
+from .coords import Orientation, PixelCoordinates, Spherical, ThreeDCoordinates
 from .exceptions import MissingCalibrationsError
 from .marker_type import MarkerType
 
@@ -45,13 +45,15 @@ class BaseMarker(ABC):
         return self.__marker_type
 
     @property
-    def pixel_corners(self) -> list[Coordinates]:
-        return [Coordinates(x=float(x), y=float(y)) for x, y in self._pixel_corners]
+    def pixel_corners(self) -> list[PixelCoordinates]:
+        return [
+            PixelCoordinates(x=float(x), y=float(y)) for x, y in self._pixel_corners
+        ]
 
     @cached_property
-    def pixel_centre(self) -> Coordinates:
+    def pixel_centre(self) -> PixelCoordinates:
         tl, _, br, _ = self.pixel_corners
-        return Coordinates(
+        return PixelCoordinates(
             x=tl.x + (self.size / 2) - 1,
             y=br.y - (self.size / 2),
         )

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from cached_property import cached_property
 from cv2 import aruco
-from numpy import arctan2, linalg
+from numpy import linalg
 from numpy.typing import NDArray
 
 from zoloto.utils import cached_method
@@ -73,10 +73,7 @@ class BaseMarker(ABC):
 
     @cached_property
     def spherical(self) -> SphericalCoordinates:
-        x, y, z = self._tvec
-        return SphericalCoordinates(
-            rot_x=float(arctan2(y, z)), rot_y=float(arctan2(x, z)), dist=self.distance
-        )
+        return SphericalCoordinates.from_cartesian(self.cartesian)
 
     @property
     def cartesian(self) -> CartesianCoordinates:

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from cached_property import cached_property
 from cv2 import aruco
-from numpy import linalg
 from numpy.typing import NDArray
 
 from zoloto.utils import cached_method
@@ -65,7 +64,7 @@ class BaseMarker(ABC):
 
     @cached_property
     def distance(self) -> int:
-        return int(linalg.norm(self._tvec))
+        return self.spherical.distance
 
     @cached_property
     def orientation(self) -> Orientation:

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -11,7 +11,7 @@ from numpy.typing import NDArray
 from zoloto.utils import cached_method
 
 from .calibration import CalibrationParameters
-from .coords import Orientation, PixelCoordinates, Spherical, ThreeDCoordinates
+from .coords import CartesianCoordinates, Orientation, PixelCoordinates, Spherical
 from .exceptions import MissingCalibrationsError
 from .marker_type import MarkerType
 
@@ -74,8 +74,8 @@ class BaseMarker(ABC):
         )
 
     @property
-    def cartesian(self) -> ThreeDCoordinates:
-        return ThreeDCoordinates(*self._tvec.tolist())
+    def cartesian(self) -> CartesianCoordinates:
+        return CartesianCoordinates(*self._tvec.tolist())
 
     @property
     def _rvec(self) -> NDArray:


### PR DESCRIPTION
Moves to using the [standard right-handed](https://en.wikipedia.org/wiki/Cartesian_coordinate_system#In_three_dimensions) coordinate system and spherical coordinates in [mathematical notation](https://mathworld.wolfram.com/SphericalCoordinates.html).

[Yaw, pitch and roll](https://en.wikipedia.org/wiki/Aircraft_principal_axes) are also corrected to their expected directions.

Setting the environment variable ZOLOTO_LEGACY_AXIS uses the axis as in version 0.9.0, except for yaw, pitch and roll which always follows their expected directions.

Builds upon https://github.com/RealOrangeOne/zoloto/pull/302.

Previously reviewed here: https://github.com/PeterJCLaw/zoloto/pull/1